### PR TITLE
Fix type of default port

### DIFF
--- a/libs/nx-serverless/src/builders/offline/schema.json
+++ b/libs/nx-serverless/src/builders/offline/schema.json
@@ -29,7 +29,7 @@
     },
     "port": {
       "type": "number",
-      "default": "7777",
+      "default": 7777,
       "description": "The port to inspect the process on. Setting port to 0 will assign random free ports to all forked processes."
     }
   },


### PR DESCRIPTION
Nx 11 throws if given a string when expecting a number
